### PR TITLE
Fix bug in SXP bit_input_stream leading to incorrect Impulse Tracker conversion

### DIFF
--- a/pmf_converter/sxp_src/core/streams.cpp
+++ b/pmf_converter/sxp_src/core/streams.cpp
@@ -112,7 +112,7 @@ void bit_input_stream::update_cache()
     m_stream.read_bytes(m_cache+num_tail_bytes, num_cache_fill_bytes);
     mem_zero(m_cache+num_tail_bytes+num_cache_fill_bytes, cache_size-num_tail_bytes-num_cache_fill_bytes);
     m_cache_bit_pos&=7;
-    m_cache_start_bit_pos+=cache_size*8;
+    m_cache_start_bit_pos+=num_cache_fill_bytes*8;
   }
 }
 //----------------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes a bug in the `bit_input_stream` type in the bundled SXP library, which is used by the `convert_it()` function in the pmf_converter tool.

When refilling the internal cache buffer in  `bit_input_stream`, the `m_cache_start_bit_pos` variable is always moved forward by a full buffer size, even when fewer bytes than that have been read from the stream. This leads to the `bit_input_stream` reporting end-of-stream much earlier than intended, which cuts the sample short.

This PR fixes issue #9. After application of this PR, the full voice sample can be heard.